### PR TITLE
Update IO_Meg.jl

### DIFF
--- a/src/IO_Meg.jl
+++ b/src/IO_Meg.jl
@@ -170,6 +170,9 @@ function load_BSepochs(subject_path::String)
 
     # Getting epoch files
     epoch_files = filter(x -> x[1:4] == "data", dir_contents)
+    # The trials have a specific keyword trial
+    epoch_files = filter(contains("trial"), epoch_files)
+    
     epoch_conditions = Vector{String}(undef, length(epoch_files))
     for (idx, file) in enumerate(epoch_files)
 


### PR DESCRIPTION
Added specfic keyword for pulling out trials. Previously only data was used, but when you make an average the format is data_XX_average_XXXXXX_XXXX and gets picked up incorrectly